### PR TITLE
Fix/7 not working on mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,7 +52,9 @@ export default function HomePage() {
         roomType: "canvas",
       });
 
-      await copyRoomUrlToClipboard(newRoomId);
+      // Try to copy to clipboard, but don't block room creation if it fails
+      copyRoomUrlToClipboard(newRoomId);
+
       router.push(`/room/${newRoomId}`);
     } catch (error) {
       console.error("Failed to create room:", error);

--- a/src/utils/copy-text-to-clipboard.ts
+++ b/src/utils/copy-text-to-clipboard.ts
@@ -1,7 +1,13 @@
 export async function copyTextToClipboard(text: string): Promise<boolean> {
   if ("clipboard" in navigator) {
-    await navigator.clipboard.writeText(text);
-    return true;
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      // Handle permission denied, not allowed errors, etc.
+      console.warn("Clipboard access failed:", error);
+      return false;
+    }
   } else {
     return false;
   }


### PR DESCRIPTION
Updated copyTextToClipboard to catch and log clipboard access errors, returning false on failure. Room creation no longer awaits clipboard copy, ensuring navigation proceeds even if copying fails. Close #7 